### PR TITLE
Win: fix random read errors

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -27,6 +27,48 @@ process_is_incompelete_error <- function(self, private) {
   isIncomplete(process_get_error_connection(self, private))
 }
 
+process_read_all_output <- function(self, private) {
+  self$wait()
+  con <- self$get_output_connection()
+  result <- ""
+  while (self$is_incomplete_output()) {
+    self$poll_io(-1)
+    result <- paste0(result, readChar(con, 1024))
+  }
+  result
+}
+
+process_read_all_error <- function(self, private) {
+  self$wait()
+  con <- self$get_error_connection()
+  result <- ""
+  while (self$is_incomplete_error()) {
+    self$poll_io(-1)
+    result <- paste0(result, readChar(con, 1024))
+  }
+  result
+}
+
+process_read_all_output_lines <- function(self, private, ...) {
+  self$wait()
+  results <- character()
+  while (self$is_incomplete_output()) {
+    self$poll_io(-1)
+    results <- c(results, self$read_output_lines(...))
+  }
+  results
+}
+
+process_read_all_error_lines <- function(self, private, ...) {
+  self$wait()
+  results <- character()
+  while (self$is_incomplete_error()) {
+    self$poll_io(-1)
+    results <- c(results, self$read_error_lines(...))
+  }
+  results
+}
+
 poll_codes <- c("nopipe", "ready", "timeout", "closed", "silent")
 
 process_poll_io <- function(self, private, ms) {

--- a/R/process.R
+++ b/R/process.R
@@ -31,6 +31,10 @@ NULL
 #' p$get_error_connection()
 #' p$is_incomplete_output()
 #' p$is_incomplete_error()
+#' p$read_all_output()
+#' p$read_all_error()
+#' p$read_all_output_lines(...)
+#' p$read_all_error_lines(...)
 #'
 #' p$poll_io(timeout)
 #'
@@ -134,6 +138,30 @@ NULL
 #' the standard error connection was closed (most probably because the
 #' process exited). It return \code{TRUE} otherwise.
 #'
+#' \code{$read_all_output()} waits for all standard output from the process.
+#' It does not return until the process has finished.
+#' Note that this process involves waiting for the process to finish,
+#' polling for I/O and potentically several `readLines()` calls.
+#' It returns a character scalar.
+#'
+#' \code{$read_all_error()} waits for all standard error from the process.
+#' It does not return until the process has finished.
+#' Note that this process involves waiting for the process to finish,
+#' polling for I/O and potentically several `readLines()` calls.
+#' It returns a character scalar.
+#'
+#' \code{$read_all_output_lines()} waits for all standard output lines
+#' from a process. It does not return until the process has finished.
+#' Note that this process involves waiting for the process to finish,
+#' polling for I/O and potentically several `readLines()` calls.
+#' It returns a character vector.
+#'
+#' \code{$read_all_error_lines()} waits for all standard error lines from
+#' a process. It does not return until the process has finished.
+#' Note that this process involves waiting for the process to finish,
+#' polling for I/O and potentically several `readLines()` calls.
+#' It returns a character vector.
+#'
 #' \code{$poll_io()} polls the process's connections for I/O. See more in
 #' the \emph{Polling} section, and see also the \code{\link{poll}} function
 #' to poll on multiple processes.
@@ -230,6 +258,18 @@ process <- R6Class(
 
     get_error_connection = function()
       process_get_error_connection(self, private),
+
+    read_all_output = function()
+      process_read_all_output(self, private),
+
+    read_all_error = function()
+      process_read_all_error(self, private),
+
+    read_all_output_lines = function(...)
+      process_read_all_output_lines(self, private, ...),
+
+    read_all_error_lines = function(...)
+      process_read_all_error_lines(self, private, ...),
 
     poll_io = function(timeout)
       process_poll_io(self, private, timeout)

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -32,6 +32,10 @@ p$get_output_connection()
 p$get_error_connection()
 p$is_incomplete_output()
 p$is_incomplete_error()
+p$read_all_output()
+p$read_all_error()
+p$read_all_output_lines(...)
+p$read_all_error_lines(...)
 
 p$poll_io(timeout)
 
@@ -138,6 +142,30 @@ process exited). It return \code{TRUE} otherwise.
 \code{$is_incomplete_error()} return \code{FALSE} if the other end of
 the standard error connection was closed (most probably because the
 process exited). It return \code{TRUE} otherwise.
+
+\code{$read_all_output()} waits for all standard output from the process.
+It does not return until the process has finished.
+Note that this process involves waiting for the process to finish,
+polling for I/O and potentically several \code{readLines()} calls.
+It returns a character scalar.
+
+\code{$read_all_error()} waits for all standard error from the process.
+It does not return until the process has finished.
+Note that this process involves waiting for the process to finish,
+polling for I/O and potentically several \code{readLines()} calls.
+It returns a character scalar.
+
+\code{$read_all_output_lines()} waits for all standard output lines
+from a process. It does not return until the process has finished.
+Note that this process involves waiting for the process to finish,
+polling for I/O and potentically several \code{readLines()} calls.
+It returns a character vector.
+
+\code{$read_all_error_lines()} waits for all standard error lines from
+a process. It does not return until the process has finished.
+Note that this process involves waiting for the process to finish,
+polling for I/O and potentically several \code{readLines()} calls.
+It returns a character vector.
 
 \code{$poll_io()} polls the process's connections for I/O. See more in
 the \emph{Polling} section, and see also the \code{\link{poll}} function

--- a/src/win/stdio.c
+++ b/src/win/stdio.c
@@ -223,6 +223,8 @@ size_t processx__con_read(void *target, size_t sz, size_t ni,
   /* We don't have anything. If there is no read pending, we
      start one. It might return synchronously, the little bastard. */
   if (! handle->read_pending) {
+    handle->overlapped.Offset = 0;
+    handle->overlapped.OffsetHigh = 0;
     result = ReadFile(
       pipe,
       handle->buffer,
@@ -454,6 +456,8 @@ HANDLE processx__stdio_handle(BYTE* buffer, int fd) {
 
 DWORD processx__poll_start_read(processx_pipe_handle_t *handle, int *result) {
   BOOLEAN res;
+  handle->overlapped.Offset = 0;
+  handle->overlapped.OffsetHigh = 0;
   res = ReadFile(
     handle->pipe,
     handle->buffer,

--- a/src/win/stdio.c
+++ b/src/win/stdio.c
@@ -227,7 +227,7 @@ size_t processx__con_read(void *target, size_t sz, size_t ni,
       pipe,
       handle->buffer,
       sz * ni < handle->buffer_size ? sz * ni : handle->buffer_size,
-      &bytes_read,
+      NULL,
       &handle->overlapped);
 
     if (!result) {
@@ -459,7 +459,7 @@ DWORD processx__poll_start_read(processx_pipe_handle_t *handle, int *result) {
     handle->pipe,
     handle->buffer,
     handle->buffer_size,
-    &bytes_read,
+    NULL,
     &handle->overlapped);
 
   if (!res) {

--- a/tests/testthat/test-chr-io.R
+++ b/tests/testthat/test-chr-io.R
@@ -10,8 +10,8 @@ test_that("Can read last line without trailing newline", {
   }
 
   p <- process$new(commandline = cmd, stdout = "|")
-  p$wait()
-  expect_equal(p$read_output_lines(), "foobar")
+  out <- p$read_all_output_lines()
+  expect_equal(out, "foobar")
 })
 
 test_that("Can read single characters", {
@@ -26,9 +26,13 @@ test_that("Can read single characters", {
   p$wait()
   con <- p$get_output_connection()
 
+  p$poll_io(-1)
   expect_equal(readChar(con, 1), "1")
+  p$poll_io(-1)
   expect_equal(readChar(con, 1), "2")
+  p$poll_io(-1)
   expect_equal(readChar(con, 1), "3")
+  p$poll_io(-1)
   expect_equal(readChar(con, 1), "\n")
 })
 
@@ -44,8 +48,12 @@ test_that("Can read multiple characters", {
   p$wait()
   con <- p$get_output_connection()
 
+  p$poll_io(-1)
   expect_equal(readChar(con, 3), "123")
+  p$poll_io(-1)
   expect_equal(readChar(con, 4), "4567")
+  p$poll_io(-1)
   expect_equal(readChar(con, 2), "89")
+  p$poll_io(-1)
   expect_equal(readChar(con, 10), "\n")
 })

--- a/tests/testthat/test-chr-io.R
+++ b/tests/testthat/test-chr-io.R
@@ -28,11 +28,8 @@ test_that("Can read single characters", {
 
   p$poll_io(-1)
   expect_equal(readChar(con, 1), "1")
-  p$poll_io(-1)
   expect_equal(readChar(con, 1), "2")
-  p$poll_io(-1)
   expect_equal(readChar(con, 1), "3")
-  p$poll_io(-1)
   expect_equal(readChar(con, 1), "\n")
 })
 
@@ -50,10 +47,7 @@ test_that("Can read multiple characters", {
 
   p$poll_io(-1)
   expect_equal(readChar(con, 3), "123")
-  p$poll_io(-1)
   expect_equal(readChar(con, 4), "4567")
-  p$poll_io(-1)
   expect_equal(readChar(con, 2), "89")
-  p$poll_io(-1)
   expect_equal(readChar(con, 10), "\n")
 })

--- a/tests/testthat/test-commandline.R
+++ b/tests/testthat/test-commandline.R
@@ -27,8 +27,8 @@ test_that("'commandline' works", {
 
   expect_true(p$is_alive())
 
-  p$wait()
-
-  expect_equal(p$read_output_lines(), "kuku")
-  expect_equal(p$read_error_lines(), "kuku2")
+  out <- p$read_all_output_lines()
+  err <- p$read_all_error_lines()
+  expect_equal(out, "kuku")
+  expect_equal(err, "kuku2")
 })

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -140,9 +140,7 @@ test_that("readChar on IO, unix", {
 
   p$poll_io(-1)
   expect_equal(readChar(con, 5), "hello")
-  p$poll_io(-1)
   expect_equal(readChar(con, 5), " worl")
-  p$poll_io(-1)
   expect_equal(readChar(con, 5), "d!\n")
 })
 


### PR DESCRIPTION
This fixes all checks on win-builder.

The key is that we need to reset the `Offset` and `OffsetHigh` members in `OVERLAPPED`, 
beefore a `ReadFile`. These should be ignored for pipess, but apparently, they are not.

Other changes:
* the new `read_all_*` methods
* force async reads by setting the pointer to the number of the number
  of bytes read, to `NULL`
* fixed some test cases that assumed that after a `wait()` all the output/error can be read out immediately.
